### PR TITLE
Upgrade to XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,29 +1,21 @@
 plugins {
     id 'maven-publish'
-    id 'com.enonic.xp.app' version '3.6.2'
+    id 'com.enonic.xp.app'
     id 'com.enonic.defaults' version '2.1.6'
 }
 
-app {
-    name = project.appName
-    displayName = 'Status Info'
-    vendorName = 'Enonic'
-    vendorUrl = 'https://enonic.com'
-    systemVersion = "${xpVersion}"
-}
-
 dependencies {
-    include "com.enonic.xp:lib-content:${xpVersion}"
-    include "com.enonic.xp:lib-admin:${xpVersion}"
-    include "com.enonic.xp:lib-portal:${xpVersion}"
-    include "com.enonic.lib:lib-admin-ui:${libAdminUiVersion}"
-    include 'com.enonic.lib:lib-thymeleaf:2.1.1'
-    include 'com.enonic.lib:lib-http-client:3.2.2'
+    include xplibs.content
+    include xplibs.admin
+    include xplibs.portal
+    include libs.lib.admin.ui
+    include libs.lib.thymeleaf
+    include libs.lib.http.client
     webjar "org.webjars:momentjs:2.30.1-1"
 }
 
 repositories {
     mavenLocal()
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo( "dev" )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,5 @@
 group = com.enonic.app
 projectName = status
 appName = com.enonic.app.status
-xpVersion = 7.0.0
-libAdminUiVersion = 3.0.0
+xpVersion = 8.0.0-B4
 version=2.3.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+thymeleaf  = "3.0.0-SNAPSHOT"
+http-client = "3.2.2"
+admin-ui   = "5.2.0-B1"
+
+[libraries]
+lib-thymeleaf   = { module = "com.enonic.lib:lib-thymeleaf",   version.ref = "thymeleaf" }
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
+lib-admin-ui    = { module = "com.enonic.lib:lib-admin-ui",    version.ref = "admin-ui" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName

--- a/src/main/resources/admin/tools/system-info/system-info.html
+++ b/src/main/resources/admin/tools/system-info/system-info.html
@@ -71,16 +71,11 @@
     <script type="text/javascript" data-th-inline="javascript">
     /*<![CDATA[*/
         var CONFIG = {
-            //adminUrl: [[${adminUrl}]],
-            //appId: [[${appId}]],
-            //assetsUri: [[${assetsUri}]],
-            launcherUrl: [[${launcherUrl}]],
             services: {}, // Workaround for i18nUrl BUG
             serviceUrl: [[${serviceUrl}]] // Used in app-main.js
         };
     /*]]>*/
     </script>
-    <script type="text/javascript" data-th-src="${launcherPath}" async></script>
     <script type="text/javascript" data-th-src="${portal.assetUrl({'_path=vendor/jquery-3.4.1.min.js'})}"></script>
     <script type="text/javascript" data-th-src="${portal.assetUrl({'_path=js/app-main.js'})}"></script>
 </body>

--- a/src/main/resources/admin/tools/system-info/system-info.js
+++ b/src/main/resources/admin/tools/system-info/system-info.js
@@ -1,9 +1,7 @@
 var portalLib = require('/lib/xp/portal');
 var thymeleaf = require('/lib/thymeleaf');
 var httpClientLib = require('/lib/http-client');
-var adminLib = require('/lib/xp/admin');
 var getUrl = require('/lib/util').getUrl;
-var timestamp = Date.now();
 
 function getStatus(url) {
 
@@ -28,12 +26,9 @@ function handleGet(req) {
     data = JSON.parse(data.body);
 
     var params = {
-        adminUrl: portalLib.url({path: "/admin"}),
         assetsUri: portalLib.assetUrl({
             path: ''
         }),
-        launcherPath: adminLib.getLauncherPath(),
-        launcherUrl: adminLib.getLauncherUrl(),
         appId: 'system-info',
         appName: 'System info',
         data: data,

--- a/src/main/resources/admin/tools/system-info/system-info.xml
+++ b/src/main/resources/admin/tools/system-info/system-info.xml
@@ -1,7 +1,0 @@
-<tool xmlns="urn:enonic:xp:model:1.0">
-  <display-name>Status info</display-name>
-  <description>Show server status and system info</description>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</tool>

--- a/src/main/resources/admin/tools/system-info/system-info.yaml
+++ b/src/main/resources/admin/tools/system-info/system-info.yaml
@@ -1,0 +1,11 @@
+kind: "AdminTool"
+title:
+  text: "Status info"
+description:
+  text: "Show server status and system info"
+allow:
+  - "role:system.admin"
+apis:
+  - "admin:extension"
+  - "admin:event"
+  - "admin:status"

--- a/src/main/resources/application.xml
+++ b/src/main/resources/application.xml
@@ -1,3 +1,0 @@
-<application>
-  <description>Show system status information.</description>
-</application>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,2 @@
+kind: "Application"
+description: "Show system status information."


### PR DESCRIPTION
## Summary

Upgrades the app to XP 8, following the `xp-app-upgrader` skill workflow.

**`xpVersion` change:** `7.0.0` → `8.0.0-B4`

### Categories of changes

- **Settings plugin added:** `settings.gradle` declares `com.enonic.xp.settings` `4.0.0-B1` (the central XP 8 plumbing — supplies the `com.enonic.xp.app` plugin version and the `xplibs.*` catalog).
- **Descriptors converted to YAML** (via `xp8migrator`):
  - `src/main/resources/application.xml` → `application.yaml` (`kind: "Application"`).
  - `src/main/resources/admin/tools/system-info/system-info.xml` → `system-info.yaml` (`kind: "AdminTool"`, with `title`/`description` as `{ text }` objects and an explicit `apis:` list — `admin:extension`, `admin:event`, `admin:status` — required by XP 8's strict API mounting).
- **`build.gradle` reorganized:**
  - Dropped the `version '3.6.2'` pin from `com.enonic.xp.app` (now supplied by the settings plugin).
  - Removed the `app { }` metadata block (XP 8 reads metadata from `application.yaml`).
  - Switched `com.enonic.xp:lib-*` deps to the `xplibs.*` catalog (`xplibs.content`, `xplibs.admin`, `xplibs.portal`).
  - Switched `xp.enonicRepo()` → `xp.enonicRepo("dev")` to resolve `lib-thymeleaf:3.0.0-SNAPSHOT`.
- **Third-party `com.enonic.lib:*` deps moved to `gradle/libs.versions.toml`** Gradle version catalog (3 deps so a catalog is warranted per the skill):
  - `lib-thymeleaf` `2.1.1` → `3.0.0-SNAPSHOT` (XP 8 compatible).
  - `lib-admin-ui` `3.0.0` → `5.2.0-B1` (latest).
  - `lib-http-client` `3.2.2` (unchanged).
- **`gradle.properties`:** dropped `libAdminUiVersion` (now in catalog); bumped `xpVersion`.
- **Gradle wrapper bumped** `8.5` → `9.4.1` (required by settings plugin 4.x).
- **Code fix in admin tool:** `system-info.js` and `system-info.html` no longer reference `adminLib.getLauncherPath()` / `getLauncherUrl()` — both were removed from `lib-admin` in XP 8 and the launcher script is no longer injected.

### Validation

`./gradlew clean build` is green on this branch (Gradle 9.4.1, Java 25). **Runtime verification was not performed** — the upgrade environment is sandboxed and ephemeral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)