### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = status
 appName = com.enonic.app.status
 xpVersion = 8.0.0-B4
-version=2.3.0-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
Bumps master to the next major SNAPSHOT for XP 8 work, while keeping the XP 7 maintenance line on `2.x`.

## Changes

- `gradle.properties`: `version=2.3.0-SNAPSHOT` → `version=3.0.0-SNAPSHOT`
- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` listing both `master` and `2.x` so pushes to either branch are recognized as release-branch builds

## Notes

- Maintenance branch `2.x` was created at the post-release SNAPSHOT commit `7dd583d` (gradle.properties at `2.3.0-SNAPSHOT`).
- A companion PR against `2.x` adds the same `releaseBranch:` block there.