### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the GitHub Actions workflow to the `2.x` maintenance branch with a `releaseBranch:` block listing both `master` and `2.x`, so pushes to `2.x` are recognized as release-branch builds.

The workflow file did not exist on the maintenance branch source commit; this PR introduces it with the modern `enonic/release-tools/build-and-publish` invocation, mirroring the master workflow.

No version bump or other changes — those are master-only per the app-booster reference.