### PR TITLE
Fix status service for XP 8 #51

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf  = "3.0.0-SNAPSHOT"
-http-client = "3.2.2"
+http-client = "4.0.0-SNAPSHOT"
 admin-ui   = "5.2.0-B1"
 
 [libraries]

--- a/src/main/resources/services/status/status.js
+++ b/src/main/resources/services/status/status.js
@@ -1,6 +1,6 @@
 var thymeleaf = require('/lib/thymeleaf');
 var httpClientLib = require('/lib/http-client');
-var moment = require('/assets/momentjs/2.24.0/min/moment-with-locales.min.js');
+var moment = require('/assets/momentjs/2.30.1-1/moment-with-locales.min.js');
 var getUrl = require('/lib/util').getUrl;
 
 function getUptime(ms) {
@@ -70,6 +70,8 @@ function handlePost(req) {
     } else if (param == 'dump') {
         data.deadlocks = getStatus(url + 'dump.deadlocks', true);
         data.threads = getStatus(url + 'dump.threads', true);
+    } else if (param == 'cluster') {
+        data = getStatus(url + 'cluster.elasticsearch');
     } else {
         data = getStatus(url + param);
     }


### PR DESCRIPTION
Closes #51

Three changes — all required for the Status admin tool's per-view buttons
(Server / Index / JVM / Cluster / Metrics / OSGI Bundles / Dump) to work on
XP 8.

## What changed

- **moment.js require path.** `services/status/status.js` required
  `/assets/momentjs/2.24.0/min/moment-with-locales.min.js`, but webjar bumps
  moved the file to `/assets/momentjs/2.30.1-1/moment-with-locales.min.js`
  (no `/min/` segment). Every POST to the status service was 500ing at
  script-load time with `ResourceNotFoundException`. Update the path.
- **Cluster reporter rename.** XP 8 replaced the management-port reporter
  `cluster` with `cluster.elasticsearch` (alongside a new `cluster.manager`).
  The Cluster button hit `/cluster`, got a 404 JSON, and Thymeleaf then NPE'd
  on `data.localNode.numberOfNodesSeen`. Map `cluster` → `cluster.elasticsearch`
  server-side so the existing button + template keep working.
- **lib-http-client 3.2.2 → 4.0.0-SNAPSHOT.** XP 8 line, from
  `repo.enonic.com/dev` (already configured via `xp.enonicRepo('dev')`).

## E2E result

Built on XP 8.0.0-B4 (xpVersion declared by the app), deployed fresh, logged
in as `su`. All seven service views return 200 with real data; moment.js-
formatted JVM uptime/start time renders; cluster view shows local node +
members. Bundle reaches ACTIVE; no app-attributable errors in `server.log`.

| service       | before | after |
|---------------|--------|-------|
| server        | 200    | 200   |
| jvm           | 500    | 200   |
| cluster       | 500    | 200   |
| index         | 500    | 200   |
| metrics       | 500    | 200   |
| osgi.bundle   | 500    | 200   |
| dump          | 500    | 200   |

(`server` succeeded before because the system-info admin tool's GET handler
doesn't require moment.js — it hits `/server` directly.)