### PR TITLE
Migrate to lib-asset #53

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     include libs.lib.admin.ui
     include libs.lib.thymeleaf
     include libs.lib.http.client
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     webjar "org.webjars:momentjs:2.30.1-1"
 }
 

--- a/src/main/resources/admin/tools/system-info/system-info.js
+++ b/src/main/resources/admin/tools/system-info/system-info.js
@@ -1,4 +1,5 @@
 var portalLib = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var thymeleaf = require('/lib/thymeleaf');
 var httpClientLib = require('/lib/http-client');
 var getUrl = require('/lib/util').getUrl;
@@ -26,7 +27,7 @@ function handleGet(req) {
     data = JSON.parse(data.body);
 
     var params = {
-        assetsUri: portalLib.assetUrl({
+        assetsUri: assetLib.assetUrl({
             path: ''
         }),
         appId: 'system-info',

--- a/src/main/resources/admin/tools/system-info/system-info.yaml
+++ b/src/main/resources/admin/tools/system-info/system-info.yaml
@@ -9,3 +9,4 @@ apis:
   - "admin:extension"
   - "admin:event"
   - "admin:status"
+  - "asset"


### PR DESCRIPTION
Closes #53.

## Summary

Replace the deprecated `portal.assetUrl` JS call in the system-info admin tool with `lib-asset`'s `assetUrl`. The admin tool descriptor now registers the `asset` Universal API so the bundled endpoint is mounted under the tool.

Files touched:
- `build.gradle` — add `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT` to `include` dependencies.
- `src/main/resources/admin/tools/system-info/system-info.yaml` — add `"asset"` to `apis:` alongside the existing admin APIs.
- `src/main/resources/admin/tools/system-info/system-info.js` — `require('/lib/enonic/asset')` and use its `assetUrl` instead of `portalLib.assetUrl`.

The Thymeleaf `${portal.assetUrl(...)}` calls in `system-info.html` are not in scope — those are lib-thymeleaf view functions, a separate non-deprecated API.

## Test plan

E2E verified inside `claude-dev` against the prebuilt xp-distro (8.1.0-SNAPSHOT runtime):

- [x] `./gradlew build --refresh-dependencies` clean (BUILD SUCCESSFUL).
- [x] Bundle starts and reaches ACTIVE (log: `Started application com.enonic.app.status bundle 117`).
- [x] Admin tool URL `GET /admin/com.enonic.app.status/system-info` returns 200 with rendered HTML and live status data populated from the status service.
- [x] All five asset URLs in the rendered HTML return 200 with the expected payload sizes:
  - `css/status.css` (1027 B) — Thymeleaf `portal.assetUrl`
  - `admin/common/styles/lib.css` (239 541 B) — **new lib-asset URL** at `/_/com.enonic.app.status:asset/<fingerprint>/...`
  - `img/system-info.svg` (1187 B) — Thymeleaf
  - `vendor/jquery-3.4.1.min.js` (88 145 B) — Thymeleaf
  - `js/app-main.js` (1097 B) — Thymeleaf
- [x] No errors/exceptions in `home/logs/server.log` during the run.